### PR TITLE
[Documize] Connexion impossible après nouvelle installation

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,7 +3,7 @@ location __PATH__/ {
 
   proxy_pass        http://127.0.0.1:__PORT__;
   proxy_redirect    off;
-  proxy_set_header  Host $http_host;
+  proxy_set_header  Host $host;
   proxy_set_header  X-Real-IP $remote_addr;
   proxy_set_header  X-Forwarded-Proto $scheme;
   proxy_set_header  X-Forwarded-For $remote_addr;

--- a/manifest.toml
+++ b/manifest.toml
@@ -65,7 +65,7 @@ ram.runtime = "50M"
 
     [resources.permissions]
     main.url = "/"
-    #main.auth_header = false
+    main.auth_header = false
 
     [resources.apt]
     packages = "postgresql"

--- a/scripts/install
+++ b/scripts/install
@@ -9,7 +9,7 @@ source /usr/share/yunohost/helpers
 ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
 
 salt=$(ynh_string_random --length=16)
-
+yunohost app ssowatconf
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -6,7 +6,7 @@ source /usr/share/yunohost/helpers
 # INITIALIZE AND STORE SETTINGS
 #=================================================
 
-#ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
+ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
 
 salt=$(ynh_string_random --length=16)
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -2,6 +2,8 @@
 
 source /usr/share/yunohost/helpers
 
+ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false
+yunohost app ssowatconf
 #=================================================
 # STOP SYSTEMD SERVICE
 #=================================================


### PR DESCRIPTION
https://forum.yunohost.org/t/documize-connexion-impossible-apres-nouvelle-installation/41059

A PR with a few open questions and uncertainties : @ericg successively added and then commented out `ynh_app_setting_set --key=protect_against_basic_auth_spoofing --value=false` in the install script. I guess because it caused an issue ? And, more generally, are there any reasons to avoid using this parameter? It seems to appear quite often in other app install or upgrade scripts.

For Documize, if we keep it in the script, it produces the expected effect, except that we need to manually run `yunohost app ssowatconf` afterwards. If we include this command directly in the script, the user is automatically logged in right after the first user is created, and everything seems fine.
However, I did not see this combination of the two commands in any other apps...

Both commands are currently present in the install and in the upgrade scripts (to be decided).